### PR TITLE
Add automation support via WebDriver

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
 
         enum DevicePostureType {
           "continuous",
-          "folded"      
+          "folded"
         };
       </pre>
       <section>
@@ -613,6 +613,93 @@
           </p>
         </section>
       </section>
+    </section>
+    <section id="automation" class="informative">
+      <h2>
+        Automation
+      </h2>
+      <p>
+        The Device Posture API pose a challenge to test authors, as fully
+        exercising interface requires physical hardware devices. To address this
+        challenge this document define [WEBDRIVER2]
+        <a href="https://w3c.github.io/webdriver/#dfn-extension-commands">
+        extension command</a> that allow controlling device posture like in real
+        device.
+      </p>
+      <h3>
+        Extension Commands
+      </h3>
+      <h4>
+        Set device posture
+      </h4>
+      <table class="simple">
+        <tr>
+          <th>
+            HTTP Method
+          </th>
+          <th>
+            <a href="https://w3c.github.io/webdriver/#dfn-extension-command-uri-template">
+            URI Template</a>
+          </th>
+        </tr>
+        <tr>
+          <td>
+            POST
+          </td>
+          <td>
+            window/deviceposture
+          </td>
+        </tr>
+      </table>
+      <p>
+        This <a href="https://w3c.github.io/webdriver/#dfn-extension-commands">
+        extension command</a> changes device posture to certain
+        {{DevicePostureType}}.
+      </p>
+      <table class="simple">
+        <caption>
+          Properties of the parameters argument used by this algorithm
+        </caption>
+        <tr>
+          <th>
+            Parameter name
+          </th>
+          <th>
+            Value type
+          </th>
+          <th>
+          Required
+          </th>
+        </tr>
+        <tr>
+          <td>
+            posture
+          </td>
+          <td>
+            String
+          </td>
+          <td>
+            yes
+          </td>
+        </tr>
+      </table>
+      <p>
+        The <a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">
+        remote end steps</a> are:
+      </p>
+      <ol class="algorithm">
+        <li>If is not {{DevicePostureType}}, return <a
+            href="https://w3c.github.io/webdriver/#dfn-error">error</a> with <a
+            href="https://w3c.github.io/webdriver/#dfn-error-code">WebDriver
+            error code</a> <a
+            href="https://w3c.github.io/webdriver/#dfn-invalid-argument">invalid
+            argument</a>.
+        </li>
+        <li>Set device posture as |posture|.
+        </li>
+        <li>Return success with data <code>null</code>.
+        </li>
+      </ol>
     </section>
     <section id="examples" class="informative">
       <h2>

--- a/index.html
+++ b/index.html
@@ -744,7 +744,7 @@
         [[\PostureOverride]]</a> to |posture|.
         </li>
         <li>Let |document| be |topLevelTraversable|'s [=navigable/active
-        document=]
+        document=].
         </li>
         <li>Invoke [=device posture change steps=] with |document|.
         </li>
@@ -793,7 +793,7 @@
         <code>null</code>.
         </li>
         <li>Let |document| be |topLevelTraversable|'s [=navigable/active
-        document=]
+        document=].
         </li>
         <li>Invoke [=device posture change steps=] with |document|.
         </li>

--- a/index.html
+++ b/index.html
@@ -688,7 +688,7 @@
         remote end steps</a> are:
       </p>
       <ol class="algorithm">
-        <li>If is not {{DevicePostureType}}, return <a
+        <li>If |posture| is not {{DevicePostureType}}, return <a
             href="https://w3c.github.io/webdriver/#dfn-error">error</a> with <a
             href="https://w3c.github.io/webdriver/#dfn-error-code">WebDriver
             error code</a> <a

--- a/index.html
+++ b/index.html
@@ -621,10 +621,8 @@
       <p>
         The Device Posture API pose a challenge to test authors, as fully
         exercising interface requires physical hardware devices. To address this
-        challenge this document defines a [[WEBDRIVER2]]
-        <a href="https://w3c.github.io/webdriver/#dfn-extension-commands">
-        extension command</a> that allow controlling device posture like in real
-        device.
+        challenge this document defines a [[WEBDRIVER2]] [=extension commands=]
+        that allow controlling device posture like in real device.
       </p>
       <h3>
         Extension Commands

--- a/index.html
+++ b/index.html
@@ -211,8 +211,8 @@
               <dfn data-dfn-for="Document">[[\OverridePosture]]</dfn>
             </td>
             <td>
-              Posture to override posture defined by hardware. Used in testing.
-              Possible values:
+              Posture to override posture defined by hardware. Used in
+              automation. Possible values:
               <li>"{{DevicePostureType/continuous}}"
               </li>
               <li>"{{DevicePostureType/folded}}"

--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
         <tbody>
           <tr>
             <td>
-              <dfn data-dfn-for="Document">[[\OverridePosture]]</dfn>
+              <dfn data-dfn-for="Document">[[\PostureOverride]]</dfn>
             </td>
             <td>
               Posture to override posture defined by hardware. Used in
@@ -477,7 +477,7 @@
         <ol class="algorithm">
           <li>If |document:Document|'s [=relevant global object=]'s
           [=navigable=]'s [=top-level
-          traversable=].{{Document/[[OverridePosture]]}} is non-null, return it.
+          traversable=].{{Document/[[PostureOverride]]}} is non-null, return it.
           </li>
           <li>Return a {{DevicePostureType}} value determined in an
           [=implementation-defined=] way based on the current hinge angle
@@ -742,7 +742,7 @@
         <a data-cite="webdriver2/#dfn-current-browsing-context">current browsing
         context</a>'s [=top-level traversable=]'s [=navigable/active document=].
         </li>
-        <li>Set |document|.{{Document/[[OverridePosture]]}} to |posture|.
+        <li>Set |document|.{{Document/[[PostureOverride]]}} to |posture|.
         </li>
         <li>Invoke [=device posture change steps=] with |document|.
         </li>
@@ -752,7 +752,7 @@
       <h4>
         Clear device posture
       </h4>
-      <li>Set |document|.{{Document/[[OverridePosture]]}} to <code>null</code>.
+      <li>Set |document|.{{Document/[[PostureOverride]]}} to <code>null</code>.
       </li>
     </section>
     <section id="examples" class="informative">

--- a/index.html
+++ b/index.html
@@ -646,7 +646,7 @@
             POST
           </td>
           <td>
-            window/deviceposture
+            deviceposture
           </td>
         </tr>
       </table>

--- a/index.html
+++ b/index.html
@@ -614,7 +614,7 @@
         </section>
       </section>
     </section>
-    <section data-link-for="DevicePostureType">
+    <section>
       <h2>
         Automation
       </h2>
@@ -687,8 +687,9 @@
         <li>Let |posture| be the result of invoking get a property "posture"
         from |parameters|.
         </li>
-        <li>If |posture| is neither <a>continuous</a> nor <a>folded</a>, return
-        [=error=] with [=error code|WebDriver error code=] [=invalid argument=].
+        <li>If |posture| is neither {{DevicePostureType/continuous}} nor
+        {{DevicePostureType/folded}}, return [=error=] with
+        [=error code|WebDriver error code=] [=invalid argument=].
         </li>
         <li>Let |document| be the |context|'s [=navigable/active document=].
         </li>

--- a/index.html
+++ b/index.html
@@ -188,11 +188,11 @@
         </tbody>
       </table>
       <h4>
-        [=Top-level traversable=]'s {{Document}} interface
+        [=Relevant global object=]'s [=navigable=]'s [=top-level traversable=]
       </h4>
       <p>
-        The following internal slots are added to the
-        [=top-level traversable=]'s {{Document}} interface.
+        The following internal slots are added to the [=relevant global
+        object=]'s [=navigable=]'s [=top-level traversable=].
       </p>
       <table class="simple">
         <thead>

--- a/index.html
+++ b/index.html
@@ -752,8 +752,44 @@
       <h4>
         Clear device posture
       </h4>
-      <li>Set |document|.{{Document/[[PostureOverride]]}} to <code>null</code>.
-      </li>
+      <table class="simple">
+        <tr>
+          <th>
+            HTTP Method
+          </th>
+          <th>
+            [=extension command URI Template|URI Template=]
+          </th>
+        </tr>
+        <tr>
+          <td>
+            DELETE
+          </td>
+          <td>
+            /session/{session id}/deviceposture
+          </td>
+        </tr>
+      </table>
+      <p>
+        This [=extension commands|extension command=] removes device posture
+        override and returns device posture control back to hardware.
+      </p>
+      <p>
+        The [=remote end steps=] are:
+      </p>
+      <ol class="algorithm">
+        <li>Let |document| be the
+        <a data-cite="webdriver2/#dfn-current-browsing-context">current browsing
+        context</a>'s [=top-level traversable=]'s [=navigable/active document=].
+        </li>
+        <li>Set |document|.{{Document/[[PostureOverride]]}} to
+        <code>null</code>.
+        </li>
+        <li>Invoke [=device posture change steps=] with |document|.
+        </li>
+        <li>Return success with data <code>null</code>.
+        </li>
+      </ol>
     </section>
     <section id="examples" class="informative">
       <h2>

--- a/index.html
+++ b/index.html
@@ -651,8 +651,7 @@
         </tr>
       </table>
       <p>
-        This <a href="https://w3c.github.io/webdriver/#dfn-extension-commands">
-        extension command</a> changes device posture to a specific
+        This [=extension commands|extension command=] changes device posture to a specific
         {{DevicePostureType}}.
       </p>
       <table class="simple">

--- a/index.html
+++ b/index.html
@@ -157,9 +157,6 @@
       <h3>
         Internal slots
       </h3>
-      <h4>
-        {{Document}} interface
-      </h4>
       <p>
         The following internal slots are added to the {{Document}} interface.
         As it name implies, it will house the value of the current posture the
@@ -187,12 +184,8 @@
           </tr>
         </tbody>
       </table>
-      <h4>
-        [=Relevant global object=]'s [=navigable=]'s [=top-level traversable=]
-      </h4>
       <p>
-        The following internal slots are added to the [=relevant global
-        object=]'s [=navigable=]'s [=top-level traversable=].
+        [=Top-level traversables=] must have the following internal slots:
       </p>
       <table class="simple">
         <thead>

--- a/index.html
+++ b/index.html
@@ -688,8 +688,8 @@
         <a data-cite="!WEBDRIVER2#dfn-getting-properties">get a property</a>
         "posture" from |parameters|.
         </li>
-        <li>If |posture| is neither {{DevicePostureType/continuous}} nor
-        {{DevicePostureType/folded}}, return [=error=] with
+        <li>If |posture| is neither "{{DevicePostureType/continuous}}" nor
+        "{{DevicePostureType/folded}}", return [=error=] with
         [=error code|WebDriver error code=] [=invalid argument=].
         </li>
         <li>Let |document| be the |context|'s [=navigable/active document=].

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         }],
         xref: {
           profile: "web-platform",
-        }, 
+        },
       };
     </script>
     <style>
@@ -695,12 +695,10 @@
         "{{DevicePostureType/folded}}", return [=error=] with
         [=error code|WebDriver error code=] [=invalid argument=].
         </li>
-        <li>Let |document| be the |context|'s [=navigable/active document=].
+        <li>Let |document| be the [=top-level traversable=]'s
+        [=navigable/active document=].
         </li>
-        <li>[=Update the device posture information=] of |document|.
-        </li>
-        <li>[=Fire an event=] named `change` at |document|'s
-        {{Window.navigator.devicePosture}} object.
+        <li>Invoke [=device posture change steps=] with |document|.
         </li>
         <li>Return success with data <code>null</code>.
         </li>

--- a/index.html
+++ b/index.html
@@ -684,11 +684,18 @@
         The [=remote end steps=] are:
       </p>
       <ol class="algorithm" data-cite="WEBDRIVER2">
-        <li>If |posture| is neither <a>continuous</a> nor <a>folded</a>, return
-            [=error=] with [=error code|WebDriver error code=]
-            [=invalid argument=].
+        <li>Let |posture| be the result of invoking get a property "posture"
+        from |parameters|.
         </li>
-        <li>Set device posture as |posture|.
+        <li>If |posture| is neither <a>continuous</a> nor <a>folded</a>, return
+        [=error=] with [=error code|WebDriver error code=] [=invalid argument=].
+        </li>
+        <li>Let |document| be the |context|'s [=navigable/active document=].
+        </li>
+        <li><a>Update the device posture information</a> of |document|.
+        </li>
+        <li><a>Fire an event</a> named `change` at |document|'s
+        {{Window.navigator.devicePosture}} object.
         </li>
         <li>Return success with data <code>null</code>.
         </li>

--- a/index.html
+++ b/index.html
@@ -781,6 +781,10 @@
         <a data-cite="webdriver2/#dfn-current-browsing-context">current browsing
         context</a>'s [=browsing context/top-level traversable=].
         </li>
+        <li>If |topLevelTraversable|.<a data-link-for="top-level traversable">
+        [[\PostureOverride]]</a> is <code>null</code>, return success with data
+        <code>null</code>.
+        </li>
         <li>Set |topLevelTraversable|.<a data-link-for="top-level traversable">
         [[\PostureOverride]]</a> to
         <code>null</code>.

--- a/index.html
+++ b/index.html
@@ -622,7 +622,8 @@
         The Device Posture API pose a challenge to test authors, as fully
         exercising interface requires physical hardware devices. To address this
         challenge this document defines a [[WEBDRIVER2]] [=extension commands=]
-        that allow controlling device posture like in real device.
+        that allows users to control the reported device posture and simulate a
+        real device.
       </p>
       <h3>
         Extension Commands

--- a/index.html
+++ b/index.html
@@ -743,6 +743,9 @@
         <li>Set |topLevelTraversable|.<a data-link-for="top-level traversable">
         [[\PostureOverride]]</a> to |posture|.
         </li>
+        <li>Let |document| be |topLevelTraversable|'s [=navigable/active
+        document=]
+        </li>
         <li>Invoke [=device posture change steps=] with |document|.
         </li>
         <li>Return [=success=] with data <code>null</code>.
@@ -788,6 +791,9 @@
         <li>Set |topLevelTraversable|.<a data-link-for="top-level traversable">
         [[\PostureOverride]]</a> to
         <code>null</code>.
+        </li>
+        <li>Let |document| be |topLevelTraversable|'s [=navigable/active
+        document=]
         </li>
         <li>Invoke [=device posture change steps=] with |document|.
         </li>

--- a/index.html
+++ b/index.html
@@ -736,11 +736,11 @@
         "{{DevicePostureType/folded}}", return [=error=] with
         [=error code|WebDriver error code=] [=invalid argument=].
         </li>
-        <li>Let |document| be the
+        <li>Let |topLevelTraversable| be the
         <a data-cite="webdriver2/#dfn-current-browsing-context">current browsing
-        context</a>'s [=top-level traversable=]'s [=navigable/active document=].
+        context</a>'s [=browsing context/top-level traversable=].
         </li>
-        <li>Set |document|.<a data-link-for="top-level traversable">
+        <li>Set |topLevelTraversable|.<a data-link-for="top-level traversable">
         [[\PostureOverride]]</a> to |posture|.
         </li>
         <li>Invoke [=device posture change steps=] with |document|.
@@ -777,11 +777,11 @@
         The [=remote end steps=] are:
       </p>
       <ol class="algorithm">
-        <li>Let |document| be the
+        <li>Let |topLevelTraversable| be the
         <a data-cite="webdriver2/#dfn-current-browsing-context">current browsing
-        context</a>'s [=top-level traversable=]'s [=navigable/active document=].
+        context</a>'s [=browsing context/top-level traversable=].
         </li>
-        <li>Set |document|.<a data-link-for="top-level traversable">
+        <li>Set |topLevelTraversable|.<a data-link-for="top-level traversable">
         [[\PostureOverride]]</a> to
         <code>null</code>.
         </li>

--- a/index.html
+++ b/index.html
@@ -698,7 +698,8 @@
         <li>Let |document| be the [=top-level traversable=]'s
         [=navigable/active document=].
         </li>
-        <li>Invoke [=device posture change steps=] with |document|.
+        <li>Invoke [=device posture change steps=] with |document| as its
+        argument.
         </li>
         <li>Return success with data <code>null</code>.
         </li>

--- a/index.html
+++ b/index.html
@@ -745,7 +745,7 @@
         </li>
         <li>Invoke [=device posture change steps=] with |document|.
         </li>
-        <li>Return success with data <code>null</code>.
+        <li>Return [=success=] with data <code>null</code>.
         </li>
       </ol>
       <h4>
@@ -782,8 +782,8 @@
         context</a>'s [=browsing context/top-level traversable=].
         </li>
         <li>If |topLevelTraversable|.<a data-link-for="top-level traversable">
-        [[\PostureOverride]]</a> is <code>null</code>, return success with data
-        <code>null</code>.
+        [[\PostureOverride]]</a> is <code>null</code>, return [=success=] with
+        data <code>null</code>.
         </li>
         <li>Set |topLevelTraversable|.<a data-link-for="top-level traversable">
         [[\PostureOverride]]</a> to
@@ -791,7 +791,7 @@
         </li>
         <li>Invoke [=device posture change steps=] with |document|.
         </li>
-        <li>Return success with data <code>null</code>.
+        <li>Return [=success=] with data <code>null</code>.
         </li>
       </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -684,8 +684,9 @@
         The [=remote end steps=] are:
       </p>
       <ol class="algorithm" data-cite="WEBDRIVER2">
-        <li>Let |posture| be the result of invoking get a property "posture"
-        from |parameters|.
+        <li>Let |posture| be the result of invoking
+        <a data-cite="!WEBDRIVER2#dfn-getting-properties">get a property</a>
+        "posture" from |parameters|.
         </li>
         <li>If |posture| is neither {{DevicePostureType/continuous}} nor
         {{DevicePostureType/folded}}, return [=error=] with

--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@
             POST
           </td>
           <td>
-            deviceposture
+            /session/{session id}/deviceposture
           </td>
         </tr>
       </table>

--- a/index.html
+++ b/index.html
@@ -694,9 +694,9 @@
         </li>
         <li>Let |document| be the |context|'s [=navigable/active document=].
         </li>
-        <li><a>Update the device posture information</a> of |document|.
+        <li>[=Update the device posture information=] of |document|.
         </li>
-        <li><a>Fire an event</a> named `change` at |document|'s
+        <li>[=Fire an event=] named `change` at |document|'s
         {{Window.navigator.devicePosture}} object.
         </li>
         <li>Return success with data <code>null</code>.

--- a/index.html
+++ b/index.html
@@ -475,13 +475,9 @@
           {{Document}} |document:Document| are as follows:
         </p>
         <ol class="algorithm">
-          <li> Let |topLevelTraversable| be the |document:Document|'s
-          [=top-level traversable=]'s [=navigable/active document=].
-          </li>
-          <li>If |topLevelTraversable|.{{Document/[[OverridePosture]]}} contains
-          "{{DevicePostureType/continuous}}" or "{{DevicePostureType/folded}}",
-          return posture in
-          |document:Document|.{{Document/[[OverridePosture]]}}.
+          <li>If |document:Document|'s [=relevant global object=]'s
+          [=navigable=]'s [=top-level
+          traversable=].{{Document/[[OverridePosture]]}} is non-null, return it.
           </li>
           <li>Return a {{DevicePostureType}} value determined in an
           [=implementation-defined=] way based on the current hinge angle

--- a/index.html
+++ b/index.html
@@ -182,6 +182,14 @@
               The <dfn>current posture</dfn>.
             </td>
           </tr>
+          <tr>
+            <td>
+              <dfn data-dfn-for="Document">[[\OverridePosture]]</dfn>
+            </td>
+            <td>
+              Posture to override posture defined by hardware. Used in testing.
+            </td>
+          </tr>
         </tbody>
       </table>
     </section>
@@ -436,6 +444,11 @@
           {{Document}} |document:Document| are as follows:
         </p>
         <ol class="algorithm">
+          <li>If |document:Document|.{{Document/[[OverridePosture]]}} contains
+          "{{DevicePostureType/continuous}}" or "{{DevicePostureType/folded}}",
+          return posture in
+          |document:Document|.{{Document/[[OverridePosture]]}}.
+          </li>
           <li>Return a {{DevicePostureType}} value determined in an
           [=implementation-defined=] way based on the current hinge angle
           value, [=current screen orientation=], as well as potential
@@ -698,11 +711,18 @@
         <li>Let |document| be the [=top-level traversable=]'s
         [=navigable/active document=].
         </li>
+        <li>Set |document|.{{Document/[[OverridePosture]]}} to |posture|.
+        </li>
         <li>Invoke [=device posture change steps=] with |document|.
         </li>
         <li>Return success with data <code>null</code>.
         </li>
       </ol>
+      <h4>
+        Clear device posture
+      </h4>
+      <li>Set |document|.{{Document/[[OverridePosture]]}} to <code>null</code>.
+      </li>
     </section>
     <section id="examples" class="informative">
       <h2>

--- a/index.html
+++ b/index.html
@@ -201,7 +201,8 @@
         <tbody>
           <tr>
             <td>
-              <dfn data-dfn-for="Document">[[\PostureOverride]]</dfn>
+              <dfn data-dfn-for="top-level traversable">[[\PostureOverride]]
+              </dfn>
             </td>
             <td>
               Posture to override posture defined by hardware. Used in
@@ -470,9 +471,11 @@
           {{Document}} |document:Document| are as follows:
         </p>
         <ol class="algorithm">
-          <li>If |document:Document|'s [=relevant global object=]'s
-          [=navigable=]'s [=top-level
-          traversable=].{{Document/[[PostureOverride]]}} is non-null, return it.
+          <li>Let |topLevelTraversable| be |document|'s [=relevant global
+          object=]'s [=navigable=]'s [=top-level traversable=].
+          </li>
+          <li>If |topLevelTraversable|.<a data-link-for="top-level traversable">
+          [[\PostureOverride]]</a> is non-null, return it.
           </li>
           <li>Return a {{DevicePostureType}} value determined in an
           [=implementation-defined=] way based on the current hinge angle
@@ -737,7 +740,8 @@
         <a data-cite="webdriver2/#dfn-current-browsing-context">current browsing
         context</a>'s [=top-level traversable=]'s [=navigable/active document=].
         </li>
-        <li>Set |document|.{{Document/[[PostureOverride]]}} to |posture|.
+        <li>Set |document|.<a data-link-for="top-level traversable">
+        [[\PostureOverride]]</a> to |posture|.
         </li>
         <li>Invoke [=device posture change steps=] with |document|.
         </li>
@@ -777,7 +781,8 @@
         <a data-cite="webdriver2/#dfn-current-browsing-context">current browsing
         context</a>'s [=top-level traversable=]'s [=navigable/active document=].
         </li>
-        <li>Set |document|.{{Document/[[PostureOverride]]}} to
+        <li>Set |document|.<a data-link-for="top-level traversable">
+        [[\PostureOverride]]</a> to
         <code>null</code>.
         </li>
         <li>Invoke [=device posture change steps=] with |document|.

--- a/index.html
+++ b/index.html
@@ -157,6 +157,9 @@
       <h3>
         Internal slots
       </h3>
+      <h4>
+        {{Document}} interface
+      </h4>
       <p>
         The following internal slots are added to the {{Document}} interface.
         As it name implies, it will house the value of the current posture the
@@ -182,12 +185,40 @@
               The <dfn>current posture</dfn>.
             </td>
           </tr>
+        </tbody>
+      </table>
+      <h4>
+        [=Top-level traversable=]'s {{Document}} interface
+      </h4>
+      <p>
+        The following internal slots are added to the
+        [=top-level traversable=]'s {{Document}} interface.
+      </p>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>
+              Internal slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tbody>
           <tr>
             <td>
               <dfn data-dfn-for="Document">[[\OverridePosture]]</dfn>
             </td>
             <td>
               Posture to override posture defined by hardware. Used in testing.
+              Possible values:
+              <li>"{{DevicePostureType/continuous}}"
+              </li>
+              <li>"{{DevicePostureType/folded}}"
+              </li>
+              <li><code>null</code>: Used when posture is defined by hardware.
+              </li>
             </td>
           </tr>
         </tbody>
@@ -444,7 +475,10 @@
           {{Document}} |document:Document| are as follows:
         </p>
         <ol class="algorithm">
-          <li>If |document:Document|.{{Document/[[OverridePosture]]}} contains
+          <li> Let |topLevelTraversable| be the |document:Document|'s
+          [=top-level traversable=]'s [=navigable/active document=].
+          </li>
+          <li>If |topLevelTraversable|.{{Document/[[OverridePosture]]}} contains
           "{{DevicePostureType/continuous}}" or "{{DevicePostureType/folded}}",
           return posture in
           |document:Document|.{{Document/[[OverridePosture]]}}.
@@ -708,8 +742,9 @@
         "{{DevicePostureType/folded}}", return [=error=] with
         [=error code|WebDriver error code=] [=invalid argument=].
         </li>
-        <li>Let |document| be the [=top-level traversable=]'s
-        [=navigable/active document=].
+        <li>Let |document| be the
+        <a data-cite="webdriver2/#dfn-current-browsing-context">current browsing
+        context</a>'s [=top-level traversable=]'s [=navigable/active document=].
         </li>
         <li>Set |document|.{{Document/[[OverridePosture]]}} to |posture|.
         </li>

--- a/index.html
+++ b/index.html
@@ -621,7 +621,7 @@
       <p>
         The Device Posture API pose a challenge to test authors, as fully
         exercising interface requires physical hardware devices. To address this
-        challenge this document define [[WEBDRIVER2]]
+        challenge this document defines a [[WEBDRIVER2]]
         <a href="https://w3c.github.io/webdriver/#dfn-extension-commands">
         extension command</a> that allow controlling device posture like in real
         device.
@@ -653,7 +653,7 @@
       </table>
       <p>
         This <a href="https://w3c.github.io/webdriver/#dfn-extension-commands">
-        extension command</a> changes device posture to certain
+        extension command</a> changes device posture to a specific
         {{DevicePostureType}}.
       </p>
       <table class="simple">

--- a/index.html
+++ b/index.html
@@ -688,6 +688,9 @@
         <a data-cite="!WEBDRIVER2#dfn-getting-properties">get a property</a>
         "posture" from |parameters|.
         </li>
+        <li>If |posture| is not a [=string=], return [=error=] with
+        [=error code|WebDriver error code=] [=invalid argument=].
+        </li>
         <li>If |posture| is neither "{{DevicePostureType/continuous}}" nor
         "{{DevicePostureType/folded}}", return [=error=] with
         [=error code|WebDriver error code=] [=invalid argument=].

--- a/index.html
+++ b/index.html
@@ -213,12 +213,14 @@
             <td>
               Posture to override posture defined by hardware. Used in
               automation. Possible values:
-              <li>"{{DevicePostureType/continuous}}"
-              </li>
-              <li>"{{DevicePostureType/folded}}"
-              </li>
-              <li><code>null</code>: Used when posture is defined by hardware.
-              </li>
+              <ul>
+                <li>"{{DevicePostureType/continuous}}"
+                </li>
+                <li>"{{DevicePostureType/folded}}"
+                </li>
+                <li><code>null</code>: Used when posture is defined by hardware.
+                </li>
+              </ul>
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -698,8 +698,7 @@
         <li>Let |document| be the [=top-level traversable=]'s
         [=navigable/active document=].
         </li>
-        <li>Invoke [=device posture change steps=] with |document| as its
-        argument.
+        <li>Invoke [=device posture change steps=] with |document|.
         </li>
         <li>Return success with data <code>null</code>.
         </li>

--- a/index.html
+++ b/index.html
@@ -614,7 +614,7 @@
         </section>
       </section>
     </section>
-    <section id="automation" class="informative">
+    <section>
       <h2>
         Automation
       </h2>

--- a/index.html
+++ b/index.html
@@ -691,7 +691,7 @@
         </tr>
       </table>
       <p>
-        This [=extension commands|extension command=] changes device posture to a specific
+        This [=extension command=] changes device posture to a specific
         {{DevicePostureType}}.
       </p>
       <table class="simple">
@@ -770,8 +770,8 @@
         </tr>
       </table>
       <p>
-        This [=extension commands|extension command=] removes device posture
-        override and returns device posture control back to hardware.
+        This [=extension command=] removes device posture override and returns
+        device posture control back to hardware.
       </p>
       <p>
         The [=remote end steps=] are:

--- a/index.html
+++ b/index.html
@@ -621,7 +621,7 @@
       <p>
         The Device Posture API pose a challenge to test authors, as fully
         exercising interface requires physical hardware devices. To address this
-        challenge this document define [WEBDRIVER2]
+        challenge this document define [[WEBDRIVER2]]
         <a href="https://w3c.github.io/webdriver/#dfn-extension-commands">
         extension command</a> that allow controlling device posture like in real
         device.

--- a/index.html
+++ b/index.html
@@ -637,8 +637,7 @@
             HTTP Method
           </th>
           <th>
-            <a href="https://w3c.github.io/webdriver/#dfn-extension-command-uri-template">
-            URI Template</a>
+            [=extension command URI Template|URI Template=]
           </th>
         </tr>
         <tr>
@@ -682,16 +681,11 @@
         </tr>
       </table>
       <p>
-        The <a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">
-        remote end steps</a> are:
+        The [=remote end steps=] are:
       </p>
-      <ol class="algorithm">
-        <li>If |posture| is not {{DevicePostureType}}, return <a
-            href="https://w3c.github.io/webdriver/#dfn-error">error</a> with <a
-            href="https://w3c.github.io/webdriver/#dfn-error-code">WebDriver
-            error code</a> <a
-            href="https://w3c.github.io/webdriver/#dfn-invalid-argument">invalid
-            argument</a>.
+      <ol class="algorithm" data-cite="WEBDRIVER2">
+        <li>If |posture| is not {{DevicePostureType}}, return [=error=] with
+            [=error code|WebDriver error code=] [=invalid argument=].
         </li>
         <li>Set device posture as |posture|.
         </li>

--- a/index.html
+++ b/index.html
@@ -614,7 +614,7 @@
         </section>
       </section>
     </section>
-    <section>
+    <section data-link-for="DevicePostureType">
       <h2>
         Automation
       </h2>
@@ -684,8 +684,9 @@
         The [=remote end steps=] are:
       </p>
       <ol class="algorithm" data-cite="WEBDRIVER2">
-        <li>If |posture| is not {{DevicePostureType}}, return [=error=] with
-            [=error code|WebDriver error code=] [=invalid argument=].
+        <li>If |posture| is neither <a>continuous</a> nor <a>folded</a>, return
+            [=error=] with [=error code|WebDriver error code=]
+            [=invalid argument=].
         </li>
         <li>Set device posture as |posture|.
         </li>


### PR DESCRIPTION
This PR integrates with the automation concepts defined in
https://w3c.github.io/device-posture/#automation to allow changing device posture through the WebDriver extension
commands defined there.

Set device posture WebDriver extension will enable overriding posture defined by hardware.

Clear device posture WebDriver extension removes device posture override and returns device posture control back to hardware.

Fixes #1_4_0
(Maybe I won't put the actual number here, but then to official)